### PR TITLE
fix: modelValue length error

### DIFF
--- a/MdEditor/layouts/Footer/MarkdownTotal.tsx
+++ b/MdEditor/layouts/Footer/MarkdownTotal.tsx
@@ -15,7 +15,7 @@ export default defineComponent({
     return () => (
       <div class={`${prefix}-footer-item`}>
         <label class={`${prefix}-footer-label`}>{ult.value.footer?.markdownTotal}:</label>
-        <span>{props.modelValue.length}</span>
+        <span>{props.modelValue?.length || 0}</span>
       </div>
     );
   }


### PR DESCRIPTION
modelValue绑定值为null时将引发props.modelValue.length属性访问错误，例如有的接口在内容为空时返回null，会导致相关错误