### PR TITLE
Use full strings for translations instead of concatenation and fix label typo

### DIFF
--- a/MdEditor/config.ts
+++ b/MdEditor/config.ts
@@ -2,9 +2,6 @@ import { CodeCss, Config, ConfigOption, Footers, StaticTextDefault } from './typ
 
 export const prefix = 'md-editor';
 
-// 编辑器ID
-export const iconScriptId = 'md-editor-v3';
-
 // 字体链接
 export const iconfontUrl = 'https://at.alicdn.com/t/c/font_2605852_4cjr7o5jo0f.js';
 
@@ -106,15 +103,16 @@ export const staticTextDefault: StaticTextDefault = {
     },
     imgTitleItem: {
       link: '添加链接',
+      linkModalTitle: '添加图片',
       upload: '上传图片',
       clip2upload: '裁剪上传'
     },
     linkModalTips: {
-      title: '添加',
-      descLable: '链接描述：',
-      descLablePlaceHolder: '请输入描述...',
-      urlLable: '链接地址：',
-      urlLablePlaceHolder: '请输入链接...',
+      title: '添加链接',
+      descLabel: '链接描述：',
+      descLabelPlaceHolder: '请输入描述...',
+      urlLabel: '链接地址：',
+      urlLabelPlaceHolder: '请输入链接...',
       buttonOK: '确定'
     },
     clipModalTips: {
@@ -185,16 +183,17 @@ export const staticTextDefault: StaticTextDefault = {
       h6: 'Lv6 Heading'
     },
     imgTitleItem: {
+      linkModalTitle: 'Add img from url',
       link: 'Add Img Link',
       upload: 'Upload Img',
       clip2upload: 'Clip Upload'
     },
     linkModalTips: {
-      title: 'Add ',
-      descLable: 'Desc:',
-      descLablePlaceHolder: 'Enter a description...',
-      urlLable: 'Link:',
-      urlLablePlaceHolder: 'Enter a link...',
+      title: 'Add link',
+      descLabel: 'Desc:',
+      descLabelPlaceHolder: 'Enter a description...',
+      urlLabel: 'Link:',
+      urlLabelPlaceHolder: 'Enter a link...',
       buttonOK: 'OK'
     },
     clipModalTips: {

--- a/MdEditor/config.ts
+++ b/MdEditor/config.ts
@@ -2,6 +2,9 @@ import { CodeCss, Config, ConfigOption, Footers, StaticTextDefault } from './typ
 
 export const prefix = 'md-editor';
 
+// 编辑器ID
+export const iconScriptId = 'md-editor-v3';
+
 // 字体链接
 export const iconfontUrl = 'https://at.alicdn.com/t/c/font_2605852_4cjr7o5jo0f.js';
 

--- a/MdEditor/layouts/Modals/Link.tsx
+++ b/MdEditor/layouts/Modals/Link.tsx
@@ -79,11 +79,11 @@ export default defineComponent({
     return () => (
       <Modal title={title.value} visible={props.visible} onClose={props.onCancel}>
         <div class={`${prefix}-form-item`}>
-          <label class={`${prefix}-lable`} for={`link-desc-${editorId}`}>
-            {ult.value.linkModalTips?.descLable}
+          <label class={`${prefix}-label`} for={`link-desc-${editorId}`}>
+            {ult.value.linkModalTips?.descLabel}
           </label>
           <input
-            placeholder={ult.value.linkModalTips?.descLablePlaceHolder}
+            placeholder={ult.value.linkModalTips?.descLabelPlaceHolder}
             class={`${prefix}-input`}
             id={`link-desc-${editorId}`}
             type="text"
@@ -95,11 +95,11 @@ export default defineComponent({
           />
         </div>
         <div class={`${prefix}-form-item`}>
-          <label class={`${prefix}-lable`} for={`link-url-${editorId}`}>
-            {ult.value.linkModalTips?.urlLable}
+          <label class={`${prefix}-label`} for={`link-url-${editorId}`}>
+            {ult.value.linkModalTips?.urlLabel}
           </label>
           <input
-            placeholder={ult.value.linkModalTips?.urlLablePlaceHolder}
+            placeholder={ult.value.linkModalTips?.urlLabelPlaceHolder}
             class={`${prefix}-input`}
             id={`link-url-${editorId}`}
             type="text"

--- a/MdEditor/layouts/Modals/Link.tsx
+++ b/MdEditor/layouts/Modals/Link.tsx
@@ -46,10 +46,10 @@ export default defineComponent({
     const title = computed(() => {
       switch (props.type) {
         case 'link': {
-          return `${ult.value.linkModalTips?.title}${ult.value.toolbarTips?.link}`;
+          return ult.value.linkModalTips?.title;
         }
         case 'image': {
-          return `${ult.value.linkModalTips?.title}${ult.value.toolbarTips?.image}`;
+          return ult.value.imgTitleItem?.linkModalTitle || ult.value.imgTitleItem?.link;
         }
         default: {
           return '';

--- a/MdEditor/styles/index.less
+++ b/MdEditor/styles/index.less
@@ -241,7 +241,7 @@
     }
   }
 
-  &-lable {
+  &-label {
     font-size: 14px;
     color: var(--md-color);
     width: 80px;

--- a/MdEditor/type.ts
+++ b/MdEditor/type.ts
@@ -63,10 +63,10 @@ export interface StaticTextDefaultValue {
   };
   linkModalTips?: {
     title?: string;
-    descLable?: string;
-    descLablePlaceHolder?: string;
-    urlLable?: string;
-    urlLablePlaceHolder?: string;
+    descLabel?: string;
+    descLabelPlaceHolder?: string;
+    urlLabel?: string;
+    urlLabelPlaceHolder?: string;
     buttonOK?: string;
   };
   clipModalTips?: {

--- a/MdEditor/type.ts
+++ b/MdEditor/type.ts
@@ -57,6 +57,7 @@ export interface StaticTextDefaultValue {
   };
   imgTitleItem?: {
     link: string;
+    linkModalTitle?: string;
     upload: string;
     clip2upload: string;
   };

--- a/README-CN.md
+++ b/README-CN.md
@@ -212,10 +212,10 @@ export interface StaticTextDefaultValue {
   // 添加链接或图片时弹窗提示
   linkModalTips?: {
     title?: string;
-    descLable?: string;
-    descLablePlaceHolder?: string;
-    urlLable?: string;
-    urlLablePlaceHolder?: string;
+    descLabel?: string;
+    descLabelPlaceHolder?: string;
+    urlLabel?: string;
+    urlLabelPlaceHolder?: string;
     buttonOK?: string;
   };
   // 裁剪图片弹窗提示，v1.2.0

--- a/README.md
+++ b/README.md
@@ -211,10 +211,10 @@ export interface StaticTextDefaultValue {
   // The modal tips of add link or upload picture
   linkModalTips?: {
     title?: string;
-    descLable?: string;
-    descLablePlaceHolder?: string;
-    urlLable?: string;
-    urlLablePlaceHolder?: string;
+    descLabel?: string;
+    descLabelPlaceHolder?: string;
+    urlLabel?: string;
+    urlLabelPlaceHolder?: string;
     buttonOK?: string;
   };
   // The modal tips of clip the picture, v1.2.0


### PR DESCRIPTION
https://github.com/imzbf/md-editor-extension/pull/2

Needs to be mirrored to the react repo