### PR TITLE
fix(mdit): support user defined highlight option

### DIFF
--- a/packages/MdEditor/layouts/Content/composition/useMarkdownIt.ts
+++ b/packages/MdEditor/layouts/Content/composition/useMarkdownIt.ts
@@ -125,8 +125,16 @@ const useMarkdownIt = (props: ContentPreviewProps, previewOnly: boolean) => {
     md.use(item.plugin, item.options);
   });
 
+  const userDefHighlight = md.options.highlight;
+
   md.set({
-    highlight: (str, language) => {
+    highlight: (str, language, attrs) => {
+      if (userDefHighlight) {
+        const result = userDefHighlight(str, language, attrs);
+        if (result) {
+          return result;
+        }
+      }
       let codeHtml;
 
       // 不高亮或者没有实例，返回默认


### PR DESCRIPTION
fix #383 

Prioritize the markdown-it highlight configuration set by the user.

### !!! Not Tested !!!