### PR TITLE
Fix footer translation error

### DIFF
--- a/packages/MdEditor/config.ts
+++ b/packages/MdEditor/config.ts
@@ -224,7 +224,7 @@ export const staticTextDefault: StaticTextDefault = {
       block: 'block'
     },
     footer: {
-      markdownTotal: 'Word Count',
+      markdownTotal: 'Character Count',
       scrollAuto: 'Scroll Auto'
     }
   }


### PR DESCRIPTION
Count in footer is incrementing on input of characters, not words. Fixing to properly describe value.