### PR TITLE
Display word count instead of character count

### DIFF
--- a/packages/MdEditor/layouts/Footer/MarkdownTotal.tsx
+++ b/packages/MdEditor/layouts/Footer/MarkdownTotal.tsx
@@ -21,7 +21,7 @@ export default defineComponent({
         <label
           class={`${prefix}-footer-label`}
         >{`${ult.value.footer?.markdownTotal}:`}</label>
-        <span>{countWords(props.modelValue)}</span>
+        <span>{props.modelValue ? countWords(props.modelValue) : 0}</span>
       </div>
     );
   }

--- a/packages/MdEditor/layouts/Footer/MarkdownTotal.tsx
+++ b/packages/MdEditor/layouts/Footer/MarkdownTotal.tsx
@@ -12,12 +12,16 @@ export default defineComponent({
   setup(props) {
     const ult = inject('usedLanguageText') as ComputedRef<StaticTextDefaultValue>;
 
+    const countWords = (text: string) => {
+      return text.trim().split(/\s+/).length;
+    };
+
     return () => (
       <div class={`${prefix}-footer-item`}>
         <label
           class={`${prefix}-footer-label`}
         >{`${ult.value.footer?.markdownTotal}:`}</label>
-        <span>{props.modelValue?.length || 0}</span>
+        <span>{countWords(props.modelValue)}</span>
       </div>
     );
   }


### PR DESCRIPTION
- This fixes the issue (#472) where the returned number on the footer was the character count instead of the word count.