### PR TITLE
feat: only show scroll switch when needed

### DIFF
--- a/packages/MdEditor/Editor.tsx
+++ b/packages/MdEditor/Editor.tsx
@@ -173,6 +173,7 @@ const Editor = defineComponent({
               modelValue={props.modelValue}
               footers={props.footers}
               defFooters={defFooters}
+              noScrollAuto={!setting.preview && !setting.htmlPreview}
               scrollAuto={state.scrollAuto}
               onScrollAutoChange={(v) => (state.scrollAuto = v)}
             />

--- a/packages/MdEditor/layouts/Footer/index.tsx
+++ b/packages/MdEditor/layouts/Footer/index.tsx
@@ -17,6 +17,9 @@ const props = {
   scrollAuto: {
     type: Boolean as PropType<boolean>
   },
+  noScrollAuto: {
+    type: Boolean as PropType<boolean>,
+  },
   onScrollAutoChange: {
     type: Function as PropType<(v: boolean) => void>,
     default: () => {}
@@ -56,7 +59,7 @@ export default defineComponent({
             return <MarkdownTotal modelValue={props.modelValue} />;
           }
           case 'scrollSwitch': {
-            return (
+            return (!props.noScrollAuto &&
               <ScrollAuto
                 scrollAuto={props.scrollAuto}
                 onScrollAutoChange={props.onScrollAutoChange}


### PR DESCRIPTION
When the editor is in preview-only mode, the Scroll Auto can cause confusion.

yet `noScrollAuto` may need to be carefully considered. Another idea is to make `scrollAuto = null` to represent `noScrollAuto`, but it seems equally elegant as this :(