### PR TITLE
fix:代码块中的copy-button标签内多一个无效双引号

### DIFF
--- a/packages/MdEditor/layouts/Content/markdownIt/code/index.ts
+++ b/packages/MdEditor/layouts/Content/markdownIt/code/index.ts
@@ -92,7 +92,7 @@ const codetabs = (md: markdownit, _opts: CodeTabsPluginOps) => {
           <div class="${prefix}-code-flag"><span></span><span></span><span></span></div>
           <div class="${prefix}-code-action">
             <span class="${prefix}-code-lang">${tokens[idx].info.trim()}</span>
-            <span class="${prefix}-copy-button" data-tips="${codeCodeText}"${isIcon ? ' data-is-icon=true' : ''}">${copyBtnHtml}</span>
+            <span class="${prefix}-copy-button" data-tips="${codeCodeText}"${isIcon ? ' data-is-icon=true' : ''}>${copyBtnHtml}</span>
             ${tagContainer === 'details' ? collapseTips : ''}
           </div>
         </${tagHeader}>${codeRendered}</${tagContainer}>`;


### PR DESCRIPTION
<img width="1579" alt="image" src="https://github.com/user-attachments/assets/f982ff9c-c313-4cc7-9b17-ad06e3b9d2b8">
删除标签内的一个无效双引号