### PR TITLE
Add Missing Labels

### DIFF
--- a/packages/MdEditor/layouts/Content/markdownIt/code/index.ts
+++ b/packages/MdEditor/layouts/Content/markdownIt/code/index.ts
@@ -129,16 +129,18 @@ const codetabs = (md: markdownit, _opts: CodeTabsPluginOps) => {
       checked = i - idx > 0 ? '' : 'checked';
 
       labels += `<li>
-          <input type="radio" name="${prefix}-codetab-label-${_opts.editorId}-${idx}" class="${className}" ${checked}>
-          <label onclick="this.getRootNode().querySelectorAll('.${className}').forEach(e => e.click())">${
+          <input type="radio" id="label-${prefix}-codetab-label-1-${_opts.editorId}-${idx}-${i - idx}" name="${prefix}-codetab-label-${_opts.editorId}-${idx}" class="${className}" ${checked}>
+          <label for="label-${prefix}-codetab-label-1-${_opts.editorId}-${idx}-${i - idx}" onclick="this.getRootNode().querySelectorAll('.${className}').forEach(e => e.click())">${
             tab || getLangName(token)
           }</label>
         </li>`;
 
-      pres += `<input type="radio" name="${prefix}-codetab-pre-${_opts.editorId}-${idx}" class="${className}" ${checked}>
+      pres += `<input type="radio" id="label-${prefix}-codetab-label-2-${_opts.editorId}-${idx}-${i - idx}"  name="${prefix}-codetab-pre-${_opts.editorId}-${idx}" class="${className}" ${checked}>
+      <label for="label-${prefix}-codetab-label-2-${_opts.editorId}-${idx}-${i - idx}" class="${prefix}-code-lang">${getLangName(token)}</label>
       ${defaultRender!(tokens, i, options, env, slf)}`;
 
-      langs += `<input type="radio" name="${prefix}-codetab-lang-${_opts.editorId}-${idx}" class="${className}" ${checked}>
+      langs += `<input type="radio" id="label-${prefix}-codetab-label-3-${_opts.editorId}-${idx}-${i - idx}"  name="${prefix}-codetab-lang-${_opts.editorId}-${idx}" class="${className}" ${checked}>
+      <label for="label-${prefix}-codetab-label-3-${_opts.editorId}-${idx}-${i - idx}" class="${prefix}-code-lang">${getLangName(token)}</label>
       <span class=${prefix}-code-lang>${getLangName(token)}</span>`;
     }
 

--- a/packages/MdEditor/layouts/Toolbar/index.tsx
+++ b/packages/MdEditor/layouts/Toolbar/index.tsx
@@ -1040,7 +1040,13 @@ export default defineComponent({
               </div>
             </div>
           )}
+          <label
+            for={`${wrapperId}_label`}
+            style={{ display: 'none' }}
+            aria-label="File Upload"
+          ></label>
           <input
+            id={`${wrapperId}_label`}
             ref={uploadRef}
             accept="image/*"
             type="file"


### PR DESCRIPTION
Make Inputs ADA Compliant by adding Labels. I used WAVE Web Accessibility Evaluation Tools to check the compatibility of input fields and they where missing labels. Please review and/or make the input compatible.