### PR TITLE
fix(mdit): js-error TypeError: Cannot read properties of null (reading 'querySelectorAll')

### DIFF
--- a/packages/MdEditor/layouts/Content/composition/useMarkdownIt.ts
+++ b/packages/MdEditor/layouts/Content/composition/useMarkdownIt.ts
@@ -212,6 +212,8 @@ const useMarkdownIt = (props: ContentPreviewProps, previewOnly: boolean) => {
     // 生成目录
     bus.emit(editorId, CATALOG_CHANGED, headsRef.value);
 
+    if (!rootRef.value) return;
+
     nextTick(() => {
       replaceMermaid().then(() => {
         zoomMermaid(rootRef.value.querySelectorAll(`#${editorId} .${prefix}-mermaid`));


### PR DESCRIPTION
I encountered the same [issue](https://github.com/imzbf/md-editor-v3/issues/716) as described in this thread. The scenario to reproduce it might be relatively niche: switching between PC and mobile components through dynamic routes in vue-router. However, when using WebSocket to continuously stream data and incrementally display content on the page, switching between PC/mobile views (by resizing the browser) triggers this error.

![image](https://github.com/user-attachments/assets/46ba056f-b110-478b-9d3d-c36025615897)