### PR TITLE
feat: add Korean support

### DIFF
--- a/dev/Header/index.tsx
+++ b/dev/Header/index.tsx
@@ -40,6 +40,9 @@ export default defineComponent({
             <button class="btn btn-header" onClick={() => props.onLangChange('en-US')}>
               英文
             </button>
+            <button class="btn btn-header" onClick={() => props.onLangChange('ko-KR')}>
+              한국어
+            </button>
           </p>
           <p class="header-actions">
             <button

--- a/packages/MdEditor/config.ts
+++ b/packages/MdEditor/config.ts
@@ -429,6 +429,88 @@ export const staticTextDefault: StaticTextDefault = {
       markdownTotal: 'Character Count',
       scrollAuto: 'Scroll Auto'
     }
+  },
+  'ko-KR': {
+    toolbarTips: {
+      bold: '진하게',
+      underline: '밑줄',
+      italic: '기울임',
+      strikeThrough: '취소선',
+      title: '제목',
+      sub: '아래첨자',
+      sup: '췻첨자',
+      quote: '인용',
+      unorderedList: '목록',
+      orderedList: '번호와 목록',
+      task: '할일',
+      codeRow: '코드',
+      code: '코드 블럭',
+      link: '링크',
+      image: '사진',
+      table: '표',
+      mermaid: 'Mermaid',
+      katex: '수식',
+      revoke: '실행 취소',
+      next: '다시 실행',
+      save: '저장',
+      prettier: '내용 정리',
+      pageFullscreen: '페이지 전체화면',
+      fullscreen: '전체화면',
+      preview: '미리보기',
+      previewOnly: '미리보기만',
+      htmlPreview: 'HTML 미리보기',
+      catalog: '카탈로그',
+      github: '소스코드'
+    },
+    titleItem: {
+      h1: 'Lv1 제목',
+      h2: 'Lv2 제목',
+      h3: 'Lv3 제목',
+      h4: 'Lv4 제목',
+      h5: 'Lv5 제목',
+      h6: 'Lv6 제목'
+    },
+    imgTitleItem: {
+      link: '이미지 링크 추가',
+      upload: '이미지 업로드',
+      clip2upload: '잘라서 업로드'
+    },
+    linkModalTips: {
+      linkTitle: '링크 추가',
+      imageTitle: '이미지 추가',
+      descLabel: '설명:',
+      descLabelPlaceHolder: '설명 입력...',
+      urlLabel: '링크:',
+      urlLabelPlaceHolder: '링크 입력...',
+      buttonOK: '확인'
+    },
+    clipModalTips: {
+      title: '이미지 자르기',
+      buttonUpload: '업로드'
+    },
+    copyCode: {
+      text: '복사',
+      successTips: '복사되었습니다!',
+      failTips: '복사에 실패했습니다!'
+    },
+    mermaid: {
+      flow: '흐름',
+      sequence: '순서',
+      gantt: '간트',
+      class: '클래스',
+      state: '상태',
+      pie: '파이',
+      relationship: '관계',
+      journey: '여정'
+    },
+    katex: {
+      inline: '수식',
+      block: '수식 블럭'
+    },
+    footer: {
+      markdownTotal: '글자 수',
+      scrollAuto: '자동 스크롤'
+    }
   }
 };
 

--- a/packages/MdEditor/type.ts
+++ b/packages/MdEditor/type.ts
@@ -117,6 +117,7 @@ export interface StaticTextDefaultValue {
 export interface StaticTextDefault {
   'zh-CN': StaticTextDefaultValue;
   'en-US': StaticTextDefaultValue;
+  'ko-KR': StaticTextDefaultValue;
 }
 
 export type StaticTextDefaultKey = keyof StaticTextDefault;

--- a/packages/config.ts
+++ b/packages/config.ts
@@ -4,3 +4,4 @@ export { prefix, config, allToolbar, allFooter, editorExtensionsAttrs } from '~/
 
 export const zh_CN = staticTextDefault['zh-CN'];
 export const en_US = staticTextDefault['en-US'];
+export const ko_KR = staticTextDefault['ko-KR'];


### PR DESCRIPTION
This pull request adds support for the Korean language to the application. The most important changes include defining Korean translations for toolbar tips

### Korean Language Support:

* [`dev/Header/index.tsx`](diffhunk://#diff-fece7fd9285213aa18910a8f1d02ff65645beee83c6122e727a31454c3ae1b08R43-R45): Added a button to switch the language to Korean (`ko-KR`).
* [`packages/MdEditor/config.ts`](diffhunk://#diff-cbb049f23a599173a9c0c4807b9528f5bee06e97765b6eb05aaa58896defb974R432-R513): Added Korean translations
* [`packages/MdEditor/type.ts`](diffhunk://#diff-335acde981ccdb86a3ccbbc7edf2b794738a01f1b51160d779fe7dc903b0e13dR120): Updated the `StaticTextDefault` interface to include the `ko-KR` language.
* [`packages/config.ts`](diffhunk://#diff-b9f9a93c62442a2333c749ccf58ae1567d2296c763e51cdf479219b60ef9c69dR7): Exported the Korean translations.