### PR TITLE
change hardcoded color value to CSS var in light theme

### DIFF
--- a/packages/MdEditor/layouts/Content/codemirror/themeLight.ts
+++ b/packages/MdEditor/layouts/Content/codemirror/themeLight.ts
@@ -7,7 +7,7 @@ import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
 import { tags as t } from '@lezer/highlight';
 
 const chalky = '#e5c07b',
-  coral = '#3f4a54',
+  coral = 'var(--md-color)',
   cyan = '#56b6c2',
   invalid = '#fff',
   ivory = '#3f4a54',


### PR DESCRIPTION
I noticed the text color was not updating to the value of `--md-color` in the light theme. I committed the same value as I spotted in the dark theme declaration file. Let me know if you'd like to fix it in another way!