### PR TITLE
fix: mermaid escapeHtml

### DIFF
--- a/packages/MdEditor/layouts/Content/markdownIt/mermaid/index.ts
+++ b/packages/MdEditor/layouts/Content/markdownIt/mermaid/index.ts
@@ -8,7 +8,7 @@ const MermaidPlugin = (md: markdownit, options: { themeRef: ComputedRef<Themes> 
   const temp = md.renderer.rules.fence!.bind(md.renderer.rules);
   md.renderer.rules.fence = (tokens, idx, ops, env, slf) => {
     const token = tokens[idx];
-    const code = md.utils.escapeHtml(token.content.trim());
+    const code = token.content.trim();
     if (token.info === 'mermaid') {
       let line;
       if (tokens[idx].map && tokens[idx].level === 0) {
@@ -26,7 +26,7 @@ const MermaidPlugin = (md: markdownit, options: { themeRef: ComputedRef<Themes> 
 
       return `<div class="${prefix}-mermaid" ${
         line !== undefined ? 'data-line=' + line : ''
-      } data-mermaid-theme=${options.themeRef.value} data-code="${code}">${code}</div>`;
+      } data-mermaid-theme=${options.themeRef.value} data-code="${md.utils.escapeHtml(code)}"></div>`;
     }
 
     return temp!(tokens, idx, ops, env, slf);

--- a/packages/MdEditor/layouts/Content/markdownIt/mermaid/index.ts
+++ b/packages/MdEditor/layouts/Content/markdownIt/mermaid/index.ts
@@ -8,7 +8,7 @@ const MermaidPlugin = (md: markdownit, options: { themeRef: ComputedRef<Themes> 
   const temp = md.renderer.rules.fence!.bind(md.renderer.rules);
   md.renderer.rules.fence = (tokens, idx, ops, env, slf) => {
     const token = tokens[idx];
-    const code = token.content.trim();
+    const code = md.utils.escapeHtml(token.content.trim());
     if (token.info === 'mermaid') {
       let line;
       if (tokens[idx].map && tokens[idx].level === 0) {


### PR DESCRIPTION
## 问题

Mermaid 插值时未转义，导致无法渲染带引号 `"` 的 mermaid 图表，且存在 XSS 风险

## 修复

使用 md.utils.escapeHtml 转义 mermaid code

## 测试用例

````
```mermaid
erDiagram
    %% 实体定义
    USER {
      Long UserId PK
      VarChar Username
      VarChar Password
      VarChar Email
      Char PhoneNumber
      VarChar School
      VarChar Major
      Char Grade
      Datetime RegisterTime
      Datetime LastLoginTime
      Integer CreditScore
    }
    
    GOODS {
      Long GoodsId PK
      VarChar GoodsName
      Text Description
      Decimal Price
      Char Condition
      VarChar Usage
      Long CategoryId
      Long PublisherId
      Datetime PublishTime
      Datetime UpdateTime
      Char GoodsStatus
    }
    
    ORDER {
      Long OrderId PK
      Long BuyerId
      Long SellerId
      Long GoodsId
      Decimal OrderAmount
      Integer Quantity
      Char PaymentStatus
      Char PaymentMethod
      VarChar LogisticsInfo
      Char OrderStatus
      Datetime CreateTime
      Datetime UpdateTime
    }
    
    EVALUATION {
      Long EvaluationId PK
      Long OrderId
      Long EvaluatorId
      Long EvaluatedId
      Text EvaluationContent
      Integer Score
      Datetime EvaluationTime
    }
    
    CATEGORY {
      Long CategoryId PK
      VarChar CategoryName
      Long ParentCategoryId
      VarChar CategoryDescription
    }
    
    TRANSACTION_RECORD {
      Long TransactionRecordId PK
      Long OrderId
      Char OperationType
      Datetime OperationTime
      VarChar OperationDescription
    }
    
    FAVORITE {
      Long FavoriteId PK
      Long UserId
      Long GoodsId
      Datetime FavoriteTime
    }
    
    BROWSING_HISTORY {
      Long BrowsingHistoryId PK
      Long UserId
      Long GoodsId
      Datetime BrowsingTime
    }
    
    NOTIFICATION {
      Long MessageId PK
      Long ReceiverUserId
      Text MessageContent
      Datetime SendTime
      Boolean IsRead
    }
    
    %% 实体之间的关系
    %% 用户发布商品：一个用户可以发布多个商品
    USER ||--o{ GOODS : publishes
    
    %% 商品属于分类：一个分类可以包含多个商品
    CATEGORY ||--o{ GOODS : categorizes
    
    %% 用户参与订单：订单中有买家和卖家（两种角色均属于USER）
    USER ||--o{ ORDER : "buys (BuyerId)"
    USER ||--o{ ORDER : "sells (SellerId)"
    
    %% 订单包含商品：一个订单对应一件商品（也可以理解为订单详情）
    GOODS ||--o{ ORDER : "is ordered in"
    
    %% 订单产生交易记录：一个订单可以有多次操作记录
    ORDER ||--o{ TRANSACTION_RECORD : triggers
    
    %% 订单与评价：一个订单可以有一条评价
    ORDER ||--|| EVALUATION : "is evaluated by"
    
    %% 用户与评价：评价中既有评价者也有被评价者
    USER ||--o{ EVALUATION : "as Evaluator (EvaluatorId)"
    USER ||--o{ EVALUATION : "as Evaluated (EvaluatedId)"
    
    %% 用户收藏商品：用户与商品之间多对多，通过收藏表体现
    USER ||--o{ FAVORITE : collects
    GOODS ||--o{ FAVORITE : "is favorited in"
    
    %% 用户浏览历史：用户与商品之间多对多，通过浏览历史表体现
    USER ||--o{ BROWSING_HISTORY : "views"
    GOODS ||--o{ BROWSING_HISTORY : "is viewed in"
    
    %% 用户接收通知：一个用户可以接收多条通知消息
    USER ||--o{ NOTIFICATION : receives
    
    %% 分类层级：一个父分类可以拥有多个子分类
    CATEGORY ||--|{ CATEGORY : "has subcategory"
```
````