### PR TITLE
feat: add support for `cropperjs@2` via `vue-modern-cropper`

### DIFF
--- a/dev/main.ts
+++ b/dev/main.ts
@@ -13,7 +13,7 @@ import { lineNumbers } from '@codemirror/view';
 // import katex from 'katex';
 // import Cropper from 'cropperjs--v1';
 // import 'cropperjs--v1/dist/cropper.css';
-import { ModernCropper } from 'vue-modern-cropper';
+// import { ModernCropper } from 'vue-modern-cropper';
 // import mermaid from 'mermaid';
 // import highlight from 'highlight.js';
 // import 'highlight.js/styles/tokyo-night-dark.css';
@@ -118,10 +118,10 @@ config({
     // katex: {
     //   instance: katex
     // },
-    cropper: {
-      //   instance: Cropper
-      component: ModernCropper
-    },
+    // cropper: {
+    //   instance: Cropper
+    //   component: ModernCropper
+    // },
     mermaid: {
       //   instance: mermaid
       enableZoom: true

--- a/dev/main.ts
+++ b/dev/main.ts
@@ -11,8 +11,9 @@ import { lineNumbers } from '@codemirror/view';
 // import DDD from './.local/DDD.vue';
 // import screenfull from 'screenfull';
 // import katex from 'katex';
-// import Cropper from 'cropperjs';
-// import 'cropperjs/dist/cropper.css';
+// import Cropper from 'cropperjs--v1';
+// import 'cropperjs--v1/dist/cropper.css';
+import { ModernCropper } from 'vue-modern-cropper';
 // import mermaid from 'mermaid';
 // import highlight from 'highlight.js';
 // import 'highlight.js/styles/tokyo-night-dark.css';
@@ -117,9 +118,10 @@ config({
     // katex: {
     //   instance: katex
     // },
-    // cropper: {
-    //   instance: Cropper
-    // },
+    cropper: {
+      //   instance: Cropper
+      component: ModernCropper
+    },
     mermaid: {
       //   instance: mermaid
       enableZoom: true

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@vue/eslint-config-prettier": "^10.0.0",
     "@vue/eslint-config-typescript": "^14.1.1",
     "axios": "^1.7.7",
-    "cropperjs": "^1.6.2",
+    "cropperjs": "^2.0.0",
     "eslint": "^9.13.0",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-vue": "^9.29.1",
@@ -83,13 +83,15 @@
     "lint-staged": "^15.4.3",
     "mermaid": "^11.3.0",
     "multiparty": "^4.2.3",
+    "cropperjs--v1": "npm:cropperjs@1",
     "prettier": "^3.2.5",
     "screenfull": "^6.0.2",
     "tsc-alias": "^1.8.10",
     "tsx": "^4.19.1",
     "typescript": "5.6.3",
     "vite": "^5.4.9",
-    "vue": "^3.5.12"
+    "vue": "^3.5.12",
+    "vue-modern-cropper": "^1.7.2"
   },
   "peerDependencies": {
     "vue": "^3.5.3"
@@ -102,5 +104,6 @@
     "*.{json,md}": [
       "prettier --write"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/packages/MdEditor/composition.ts
+++ b/packages/MdEditor/composition.ts
@@ -257,7 +257,10 @@ export const useExpansion = (props: EditorProps) => {
     noPrettier || editorExtensions.prettier!.parserMarkdownInstance;
 
   // 判断是否需要插入裁剪图片标签
-  const noCropperScript = noUploadImg || editorExtensions.cropper!.instance;
+  const noCropperScript =
+    noUploadImg ||
+    editorExtensions.cropper!.instance ||
+    editorExtensions.cropper!.component;
 
   onMounted(() => {
     // 非仅预览模式才添加扩展

--- a/packages/MdEditor/layouts/Modals/index.less
+++ b/packages/MdEditor/layouts/Modals/index.less
@@ -19,6 +19,11 @@
         width: 100%;
         height: 100%;
 
+        .@{prefix}-clip-cropper-component {
+          width: 100%;
+          height: 100%;
+        }
+
         .@{prefix}-clip-delete {
           position: absolute;
           top: 0;

--- a/packages/MdEditor/type.ts
+++ b/packages/MdEditor/type.ts
@@ -6,6 +6,7 @@ import { KeyBinding, EditorView } from '@codemirror/view';
 import { editorProps, mdPreviewProps } from './props';
 import { IconName } from './components/Icon/Icon';
 import { ToolDirective } from './utils/content-help';
+import { ModernCropper } from 'vue-modern-cropper';
 
 declare global {
   interface Window {
@@ -211,6 +212,7 @@ export interface ConfigOption {
     };
     cropper?: {
       instance?: any;
+      component?: typeof ModernCropper;
       js?: string;
       css?: string;
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -718,6 +718,105 @@
     style-mod "^4.1.0"
     w3c-keyname "^2.2.4"
 
+"@cropper/element-canvas@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@cropper/element-canvas/-/element-canvas-2.0.0.tgz#d41f47cf6fd293e6bcb78a39956d9bed24036c69"
+  integrity sha512-GPtGJgSm92crJhhhwUsaMw3rz2KfJWWSz7kRAlufFEV/EHTP5+6r6/Z1BCGRna830i+Avqbm435XLOtA7PVJwA==
+  dependencies:
+    "@cropper/element" "^2.0.0"
+    "@cropper/utils" "^2.0.0"
+
+"@cropper/element-crosshair@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@cropper/element-crosshair/-/element-crosshair-2.0.0.tgz#ff4d026a383a5b8517119e6939b0c38a58b839c1"
+  integrity sha512-KfPfyrdeFvUC31Ws7ATtcalWWSaMtrC6bMoCipZhqbUOE7wZoL4ecDSL6BUOZxPa74awZUqfzirCDjHvheBfyw==
+  dependencies:
+    "@cropper/element" "^2.0.0"
+    "@cropper/utils" "^2.0.0"
+
+"@cropper/element-grid@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@cropper/element-grid/-/element-grid-2.0.0.tgz#a5f3b3a8fb1579517cdd984da767cbe9e855f99e"
+  integrity sha512-i78SQ0IJTLFveKX6P7svkfMYVdgHrQ8ZmmEw8keFy9n1ZVbK+SK0UHK5FNMRNI/gtVhKJOGEnK/zeyjUdj4Iyw==
+  dependencies:
+    "@cropper/element" "^2.0.0"
+    "@cropper/utils" "^2.0.0"
+
+"@cropper/element-handle@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@cropper/element-handle/-/element-handle-2.0.0.tgz#44d8fa04f78eb7180efece8940cd4a6ab966e7f1"
+  integrity sha512-ZJvW+0MkK9E8xYymGdoruaQn2kwjSHFpNSWinjyq6csuVQiCPxlX5ovAEDldmZ9MWePPtWEi3vLKQOo2Yb0T8g==
+  dependencies:
+    "@cropper/element" "^2.0.0"
+    "@cropper/utils" "^2.0.0"
+
+"@cropper/element-image@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@cropper/element-image/-/element-image-2.0.0.tgz#9c6a52cb71fe0f62befb7ef3bb9d06561a9f06d0"
+  integrity sha512-9BxiTS/aHRmrjopaFQb9mQQXmx4ruhYHGkDZMVz24AXpMFjUY6OpqrWse/WjzD9tfhMFvEdu17b3VAekcAgpeg==
+  dependencies:
+    "@cropper/element" "^2.0.0"
+    "@cropper/element-canvas" "^2.0.0"
+    "@cropper/utils" "^2.0.0"
+
+"@cropper/element-selection@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@cropper/element-selection/-/element-selection-2.0.0.tgz#8b69b310cbb8e6eb15a63d077eae052b332f01c9"
+  integrity sha512-ensNnbIfJsJ8bhbJTH/RXtk2URFvTOO4TvfRk461n2FPEC588D7rwBmUJxQg74IiTi4y1JbCI+6j+4LyzYBLCQ==
+  dependencies:
+    "@cropper/element" "^2.0.0"
+    "@cropper/element-canvas" "^2.0.0"
+    "@cropper/element-image" "^2.0.0"
+    "@cropper/utils" "^2.0.0"
+
+"@cropper/element-shade@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@cropper/element-shade/-/element-shade-2.0.0.tgz#ddfcf69c5d4db20b6beae8cbfab82e69218e4a6d"
+  integrity sha512-jv/2bbNZnhU4W+T4G0c8ADocLIZvQFTXgCf2RFDNhI5UVxurzWBnDdb8Mx8LnVplnkTqO+xUmHZYve0CwgWo+Q==
+  dependencies:
+    "@cropper/element" "^2.0.0"
+    "@cropper/element-canvas" "^2.0.0"
+    "@cropper/element-selection" "^2.0.0"
+    "@cropper/utils" "^2.0.0"
+
+"@cropper/element-viewer@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@cropper/element-viewer/-/element-viewer-2.0.0.tgz#a2b67af726ee0eb6c7aa86ebb4878a051a1344d9"
+  integrity sha512-zY+3VRN5TvpM8twlphYtXw0tzJL2VgzeK7ufhL1BixVqOdRxwP13TprYIhqwGt9EW/SyJZUiaIu396T89kRX8A==
+  dependencies:
+    "@cropper/element" "^2.0.0"
+    "@cropper/element-canvas" "^2.0.0"
+    "@cropper/element-image" "^2.0.0"
+    "@cropper/element-selection" "^2.0.0"
+    "@cropper/utils" "^2.0.0"
+
+"@cropper/element@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@cropper/element/-/element-2.0.0.tgz#5eb636842aa47468de451dfab0987ef3fd783808"
+  integrity sha512-lsthn0nQq73GExUE7Mg/ss6Q3RXADGDv055hxoLFwvl/wGHgy6ZkYlfLZ/VmgBHC6jDK5IgPBFnqrPqlXWSGBA==
+  dependencies:
+    "@cropper/utils" "^2.0.0"
+
+"@cropper/elements@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@cropper/elements/-/elements-2.0.0.tgz#48782beb470c313ee964ba26ea5f163455d2f380"
+  integrity sha512-PQkPo1nUjxLFUQuHYu+6atfHxpX9B41Xribao6wpvmvmNIFML6LQdNqqWYb6LyM7ujsu71CZdBiMT5oetjJVoQ==
+  dependencies:
+    "@cropper/element" "^2.0.0"
+    "@cropper/element-canvas" "^2.0.0"
+    "@cropper/element-crosshair" "^2.0.0"
+    "@cropper/element-grid" "^2.0.0"
+    "@cropper/element-handle" "^2.0.0"
+    "@cropper/element-image" "^2.0.0"
+    "@cropper/element-selection" "^2.0.0"
+    "@cropper/element-shade" "^2.0.0"
+    "@cropper/element-viewer" "^2.0.0"
+
+"@cropper/utils@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@cropper/utils/-/utils-2.0.0.tgz#735873696e15073405ceadb9423507508d738103"
+  integrity sha512-cprLYr+7kK3faGgoOsTW9gIn5sefDr2KwOmgyjzIXk+8PLpW8FgFKEg5FoWfRD5zMAmkCBuX6rGKDK3VdUEGrg==
+
 "@esbuild/aix-ppc64@0.21.5":
   version "0.21.5"
   resolved "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz#c7184a326533fcdf1b8ee0733e21c713b975575f"
@@ -1981,10 +2080,18 @@ crelt@^1.0.5:
   resolved "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz#7cc898ea74e190fb6ef9dae57f8f81cf7302df72"
   integrity sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==
 
-cropperjs@^1.6.2:
+"cropperjs--v1@npm:cropperjs@1":
   version "1.6.2"
-  resolved "https://registry.npmjs.org/cropperjs/-/cropperjs-1.6.2.tgz#d1a5d627d880581cca41b7901f06923500e4201b"
+  resolved "https://registry.yarnpkg.com/cropperjs/-/cropperjs-1.6.2.tgz#d1a5d627d880581cca41b7901f06923500e4201b"
   integrity sha512-nhymn9GdnV3CqiEHJVai54TULFAE3VshJTXSqSJKa8yXAKyBKDWdhHarnlIPrshJ0WMFTGuFvG02YjLXfPiuOA==
+
+cropperjs@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/cropperjs/-/cropperjs-2.0.0.tgz#0dc6187a66a27e8f6de1e7320c92997dbacc854b"
+  integrity sha512-TO2j0Qre01kPHbow4FuTrbdEB4jTmGRySxW49jyEIqlJZuEBfrvCTT0vC3eRB2WBXudDfKi1Onako6DKWKxeAQ==
+  dependencies:
+    "@cropper/elements" "^2.0.0"
+    "@cropper/utils" "^2.0.0"
 
 cross-spawn@^7.0.2:
   version "7.0.3"
@@ -4033,6 +4140,11 @@ vue-eslint-parser@^9.4.3:
     esquery "^1.4.0"
     lodash "^4.17.21"
     semver "^7.3.6"
+
+vue-modern-cropper@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/vue-modern-cropper/-/vue-modern-cropper-1.7.2.tgz#1b479d84c58f39bf5157f2328a3ce7daef3a869a"
+  integrity sha512-QWF+Gpm1UN+FzYo+rqUtOTKVmVitpUkmSCRb9TaEP6KgYkmttPYhKUNF0FgldiIsLHYmZStGRZ/OM46iNfW0Dw==
 
 vue@^3.5.12:
   version "3.5.12"


### PR DESCRIPTION
Related #824

This PR adds non-breaking, opt-in support for users who want to use `cropperjs@2` via [`vue-modern-cropper`](https://github.com/NamesMT/vue-modern-cropper)

Usage:

```ts
import { ModernCropper } from 'vue-modern-cropper';

config({
  editorExtensions: {
    cropper: {
      component: ModernCropper,
    }
  }
})
```