### PR TITLE
支持多CDN配置+katex支持onerror

### DIFF
--- a/packages/MdEditor/layouts/Content/composition/useKatex.ts
+++ b/packages/MdEditor/layouts/Content/composition/useKatex.ts
@@ -18,11 +18,12 @@ const useKatex = (props: ContentPreviewProps) => {
       return;
     }
 
-    const { editorExtensions } = globalConfig;
+    const { editorExtensions, editorExtensionsAttrs } = globalConfig;
 
     appendHandler(
       'script',
       {
+        ...editorExtensionsAttrs.katex?.js,
         src: editorExtensions.katex!.js,
         id: CDN_IDS.katexjs,
         onload() {


### PR DESCRIPTION
<img width="1116" height="1374" alt="image" src="https://github.com/user-attachments/assets/ef114a0e-f942-4ba0-b297-4dcfdcd57f9b" />

一方面是支持katex配置onerror属性，主要是因为katex加载失败时是静默失败的，不会有任何提示。关键在于katex对应的原始内容默认是隐藏的，最终导致用户看到的markdown内容缺少很多数字相关内容，从而影响用户使用。
这里支持onerror之后，可以提示用户js文件加载失败了，需要刷新页面重试一下。

另一方面是支持配置多个CDN源，当第一个CDN资源加载失败时，会继续加载后面CDN的资源，只要任意CDN资源加载成功就能保证katex的加载成功。我这里只针对katex配置了双CDN，实际上也可以针对其他资源配置多CDN，只不过它们加载失败没有katex严重，所以这里就没有配置多CDN了。

期望可以合并这个pull request。但是我提交的代码有一个不好的地方就是没有适配typescript的类型定义，主要是我不太擅长typescript，有需要的话可以帮忙完善一下类型定义。