### PR TITLE
feat: Add Korean (ko-KR) language support

### DIFF
--- a/packages/MdEditor/config.ts
+++ b/packages/MdEditor/config.ts
@@ -439,6 +439,88 @@ export const staticTextDefault: StaticTextDefault = {
       markdownTotal: 'Character Count',
       scrollAuto: 'Scroll Auto'
     }
+  },
+  'ko-KR': {
+    toolbarTips: {
+      bold: '굵게',
+      underline: '밑줄',
+      italic: '기울임꼴',
+      strikeThrough: '취소선',
+      title: '제목',
+      sub: '아래 첨자',
+      sup: '위 첨자',
+      quote: '인용',
+      unorderedList: '순서 없는 목록',
+      orderedList: '순서 있는 목록',
+      task: '할 일 목록',
+      codeRow: '인라인 코드',
+      code: '코드 블록',
+      link: '링크',
+      image: '이미지',
+      table: '표',
+      mermaid: '다이어그램',
+      katex: '수식',
+      revoke: '실행 취소',
+      next: '다시 실행',
+      save: '저장',
+      prettier: '코드 정리',
+      pageFullscreen: '페이지 전체 화면',
+      fullscreen: '전체 화면',
+      preview: '미리보기',
+      previewOnly: '미리보기만',
+      htmlPreview: 'HTML 미리보기',
+      catalog: '목차',
+      github: '소스 코드'
+    },
+    titleItem: {
+      h1: '1단계 제목',
+      h2: '2단계 제목',
+      h3: '3단계 제목',
+      h4: '4단계 제목',
+      h5: '5단계 제목',
+      h6: '6단계 제목'
+    },
+    imgTitleItem: {
+      link: '링크 추가',
+      upload: '이미지 업로드',
+      clip2upload: '크롭 업로드'
+    },
+    linkModalTips: {
+      linkTitle: '링크 추가',
+      imageTitle: '이미지 추가',
+      descLabel: '설명:',
+      descLabelPlaceHolder: '설명을 입력하세요...',
+      urlLabel: '링크:',
+      urlLabelPlaceHolder: '링크를 입력하세요...',
+      buttonOK: '확인'
+    },
+    clipModalTips: {
+      title: '이미지 자르기',
+      buttonUpload: '업로드'
+    },
+    copyCode: {
+      text: '복사',
+      successTips: '복사되었습니다!',
+      failTips: '복사 실패!'
+    },
+    mermaid: {
+      flow: '플로우차트',
+      sequence: '시퀀스 다이어그램',
+      gantt: '간트 차트',
+      class: '클래스 다이어그램',
+      state: '상태 다이어그램',
+      pie: '파이 차트',
+      relationship: '관계 다이어그램',
+      journey: '여정 맵'
+    },
+    katex: {
+      inline: '인라인 수식',
+      block: '블록 수식'
+    },
+    footer: {
+      markdownTotal: '글자 수',
+      scrollAuto: '동기화 스크롤'
+    }
   }
 };
 

--- a/packages/MdEditor/type.ts
+++ b/packages/MdEditor/type.ts
@@ -119,6 +119,7 @@ export interface StaticTextDefaultValue {
 export interface StaticTextDefault {
   'zh-CN': StaticTextDefaultValue;
   'en-US': StaticTextDefaultValue;
+  'ko-KR': StaticTextDefaultValue;
 }
 
 export type StaticTextDefaultKey = keyof StaticTextDefault;

--- a/packages/config.ts
+++ b/packages/config.ts
@@ -4,3 +4,4 @@ export { prefix, config, allToolbar, allFooter, editorExtensionsAttrs } from '~/
 
 export const zh_CN = staticTextDefault['zh-CN'];
 export const en_US = staticTextDefault['en-US'];
+export const ko_KR = staticTextDefault['ko-KR'];


### PR DESCRIPTION
## Summary
This PR adds Korean language support to md-editor-v3.

## Changes
- Added Korean translations for all UI elements in `packages/MdEditor/config.ts`
- Added `ko-KR` type definition in `packages/MdEditor/type.ts`
- Exported `ko_KR` language pack in `packages/config.ts`

## Translations Include
- Toolbar tips (bold, italic, link, image, etc.)
- Modal dialogs (link/image insertion, cropping)
- Footer text (character count, scroll sync)
- Mermaid diagram types
- Katex formula types

All translations are complete and ready for Korean-speaking users.