### PR TITLE
fix(scroll): fix misalignment when syncing preview to editor at the top

### DIFF
--- a/packages/MdCatalog/MdCatalog.tsx
+++ b/packages/MdCatalog/MdCatalog.tsx
@@ -12,6 +12,7 @@ import {
   CSSProperties,
   watch
 } from 'vue';
+import CatalogLink from './CatalogLink';
 import { prefix } from '~/config';
 import {
   CATALOG_CHANGED,
@@ -23,7 +24,6 @@ import { HeadList, MdHeadingId, Themes } from '~/type';
 import { getRelativeTop } from '~/utils';
 import bus from '~/utils/event-bus';
 import { getComputedStyleNum } from '~/utils/scroll-auto';
-import CatalogLink from './CatalogLink';
 
 export interface TocItem extends HeadList {
   index: number;
@@ -371,11 +371,8 @@ const MdCatalog = defineComponent({
 
     return () => (
       <div
-        class={[
-          `${prefix}-catalog`,
-          props.theme === 'dark' && `${prefix}-catalog-dark`,
-          props.class || ''
-        ]}
+        class={[`${prefix}-catalog`, props.class || '']}
+        data-theme={props.theme}
         ref={catalogRef}
       >
         {catalogs.value.length > 0 && (

--- a/packages/MdCatalog/index.scss
+++ b/packages/MdCatalog/index.scss
@@ -63,6 +63,6 @@
   }
 }
 
-.#{$prefix}-catalog-dark {
+.#{$prefix}-catalog[data-theme='dark'] {
   @include css-vars(true);
 }

--- a/packages/MdEditor/Editor.tsx
+++ b/packages/MdEditor/Editor.tsx
@@ -1,13 +1,4 @@
 import { computed, defineComponent, onBeforeUnmount, reactive, ref } from 'vue';
-import { prefix } from '~/config';
-import Content from '~/layouts/Content';
-import Footer from '~/layouts/Footer';
-import ToolBar from '~/layouts/Toolbar';
-import { EditorContext, HeadList } from '~/type';
-import bus from '~/utils/event-bus';
-
-import { getSlot } from '~/utils/vue-tsx';
-
 import {
   useOnSave,
   useProvide,
@@ -18,9 +9,16 @@ import {
   useErrorCatcher,
   useEditorId
 } from './composition';
-
 import { ContentExposeParam } from './layouts/Content/type';
 import { editorProps as props, editorEmits as emits } from './props';
+import { prefix } from '~/config';
+import Content from '~/layouts/Content';
+import Footer from '~/layouts/Footer';
+import ToolBar from '~/layouts/Toolbar';
+import { EditorContext, HeadList } from '~/type';
+import bus from '~/utils/event-bus';
+
+import { getSlot } from '~/utils/vue-tsx';
 
 const Editor = defineComponent({
   name: 'MdEditorV3',
@@ -139,9 +137,9 @@ const Editor = defineComponent({
           class={[
             prefix,
             props.class,
-            props.theme === 'dark' && `${prefix}-dark`,
             setting.fullscreen || setting.pageFullscreen ? `${prefix}-fullscreen` : ''
           ]}
+          data-theme={props.theme}
           style={props.style}
           ref={rootRef}
         >

--- a/packages/MdEditor/layouts/Toolbar/index.scss
+++ b/packages/MdEditor/layouts/Toolbar/index.scss
@@ -136,7 +136,7 @@ $toolbar-padding: 4px;
   }
 }
 
-.#{$prefix}-dark {
+.#{$prefix}[data-theme='dark'] {
   .#{$prefix}-table-shape {
     &-col {
       &-default {

--- a/packages/MdEditor/styles/preview.scss
+++ b/packages/MdEditor/styles/preview.scss
@@ -106,7 +106,7 @@
   }
 }
 
-.#{$prefix}-dark,
+.#{$prefix}[data-theme='dark'],
 .#{$prefix}-modal-container[data-theme='dark'] {
   @include css-vars(true);
 }

--- a/packages/MdEditor/utils/scroll-auto.ts
+++ b/packages/MdEditor/utils/scroll-auto.ts
@@ -408,7 +408,7 @@ const scrollAuto = (pEle: HTMLElement, cEle: HTMLElement, codeMirrorUt: CodeMirr
       } else {
         blockHeight = endLineScrollTop;
       }
-
+      firstLineScrollTop = 0
       scale = Math.max(cScrollTop / eleEndOffsetTop, 0);
     }
     // 正常情况

--- a/packages/MdPreview/MdPreview.tsx
+++ b/packages/MdPreview/MdPreview.tsx
@@ -1,4 +1,5 @@
 import { defineComponent, onBeforeUnmount, ref } from 'vue';
+import { useExpose } from './composition/useExpose';
 import { useEditorId, useProvidePreview } from '~/composition';
 import { prefix } from '~/config';
 
@@ -6,7 +7,6 @@ import ContentPreview from '~/layouts/Content/ContentPreview';
 import { mdPreviewProps as props, mdPreviewEmits as emits } from '~/props';
 import { HeadList, MdPreviewProps } from '~/type';
 import bus from '~/utils/event-bus';
-import { useExpose } from './composition/useExpose';
 
 const MdPreview = defineComponent({
   name: 'MdPreview',
@@ -62,12 +62,8 @@ const MdPreview = defineComponent({
       return (
         <div
           id={editorId}
-          class={[
-            prefix,
-            props.class,
-            props.theme === 'dark' && `${prefix}-dark`,
-            `${prefix}-previewOnly`
-          ]}
+          class={[prefix, props.class, `${prefix}-previewOnly`]}
+          data-theme={props.theme}
           style={props.style}
           ref={rootRef}
         >


### PR DESCRIPTION
### Description
Fixed a bug where the editor and preview areas failed to align at the top when scrolling the preview area. 

### Cause
In `cEleHandler` (preview-to-editor), when `realEleStart` matches the first child, `scale` is calculated from absolute `0`, but `firstLineScrollTop` was not reset to `0`. This caused the old/cached `firstLineScrollTop` value to be added, preventing the editor from scrolling back to the absolute top.

### Solution
Explicitly set `firstLineScrollTop = 0` inside the `else if` branch for the top element area to ensure a proper 0-based scale mapping.