### PR TITLE
fix(editor): guard DOM work after unmount

### DIFF
--- a/packages/MdEditor/components/CustomScrollbar/index.tsx
+++ b/packages/MdEditor/components/CustomScrollbar/index.tsx
@@ -141,6 +141,10 @@ export default defineComponent({
 
     onMounted(async () => {
       await nextTick();
+      const wrapper = wrapperRef.value;
+
+      if (!wrapper) return;
+
       findAndBindScrollEl();
 
       // 监听 slot 内容变化（防抖）
@@ -150,7 +154,7 @@ export default defineComponent({
           findAndBindScrollEl();
         });
       });
-      observer.observe(wrapperRef.value!, {
+      observer.observe(wrapper, {
         childList: true,
         subtree: true
       });

--- a/packages/MdEditor/layouts/Content/composition/useEcharts.ts
+++ b/packages/MdEditor/layouts/Content/composition/useEcharts.ts
@@ -119,8 +119,12 @@ const useEcharts = (props: ContentPreviewProps) => {
     clearEchartsEffects();
 
     if (!props.noEcharts && echarts) {
+      const root = rootRef.value;
+
+      if (!root) return;
+
       const pendingSourceEles = Array.from(
-        rootRef.value.querySelectorAll<HTMLElement>(
+        root.querySelectorAll<HTMLElement>(
           `#${editorId} div.${prefix}-echarts:not([data-processed])`
         )
       );

--- a/packages/MdEditor/layouts/Content/composition/useMermaid.ts
+++ b/packages/MdEditor/layouts/Content/composition/useMermaid.ts
@@ -110,7 +110,11 @@ const useMermaid = (props: ContentPreviewProps) => {
 
   const replaceMermaid = async () => {
     if (!props.noMermaid && mermaid) {
-      const mermaidSourceEles = rootRef.value.querySelectorAll<HTMLElement>(
+      const root = rootRef.value;
+
+      if (!root) return;
+
+      const mermaidSourceEles = root.querySelectorAll<HTMLElement>(
         `div.${prefix}-mermaid`
       );
 


### PR DESCRIPTION
## Summary

Three downstream crashes fire when an `<MdEditor>` / `<MdPreview>` is unmounted while deferred work is still queued, because the composition functions read `rootRef.value` / `wrapperRef.value` *after* Vue has nulled the ref and a microtask has already been scheduled:

1. `useEcharts.replaceEcharts` calls `rootRef.value.querySelectorAll(...)` once a future microtask (e.g. theme change watcher or `RERENDER` bus event) fires after unmount.
2. `useMermaid.replaceMermaid` does the same on `rootRef.value.querySelectorAll(...)`. The async `await mermaid.render(...)` also keeps the captured node alive past unmount and ultimately touches `item.replaceWith(p)`.
3. `CustomScrollbar.onMounted` awaits `nextTick()` and then passes `wrapperRef.value!` straight into `MutationObserver.observe`. If unmount wins the race, `wrapperRef.value` is `null` and the observe call throws `TypeError: Failed to execute 'observe' on 'MutationObserver': The first parameter "target" should be of type "Node".` `nextTick()` alone is **not** sufficient because the ref can still be nulled after the tick resolves.

This PR captures the ref synchronously at function entry in all three locations, returns early if the ref is absent, and uses the captured value for the rest of the work.

## Root cause

Each of the three functions followed a pattern that races against unmount:

```ts
// before
const replaceEcharts = () => {
  clearEchartsEffects();
  if (!props.noEcharts && echarts) {
    Array.from(rootRef.value.querySelectorAll(...)) // throws if rootRef.value is null
  }
}
```

```ts
// before
onMounted(async () => {
  await nextTick();
  findAndBindScrollEl();
  observer = new MutationObserver(() => { ... });
  observer.observe(wrapperRef.value!, { ... }); // throws if wrapperRef.value is null
  // ...event listeners...
});
```

The fix captures the ref into a local at the top of the work, guards it, and uses the captured value throughout. This is the same pattern already used elsewhere in the codebase (e.g. `useTaskState`).

## Reproduction / source mappings

| File | Upstream symptom | Diff hunk |
|---|---|---|
| `packages/MdEditor/layouts/Content/composition/useEcharts.ts` | `Cannot read properties of null (reading 'querySelectorAll')` after unmount + deferred watcher | `replaceEcharts` now captures `root = rootRef.value` and `if (!root) return;` |
| `packages/MdEditor/layouts/Content/composition/useMermaid.ts` | Same null-rootRef throw; async tail of `replaceMermaid` also touches `item.replaceWith(p)` after unmount | `replaceMermaid` captures `root = rootRef.value`, guards, uses `root.querySelectorAll(...)` |
| `packages/MdEditor/components/CustomScrollbar/index.tsx` | `TypeError: Failed to execute 'observe' on 'MutationObserver': The first parameter "target" should be of type "Node"` after unmount + nextTick | `onMounted` captures `wrapper = wrapperRef.value` after `nextTick`, `if (!wrapper) return;`, then `observer.observe(wrapper, ...)`, listeners added only after the guard |

A minimal Vue 3 + happy-dom + Vitest harness (run against the npm-published `md-editor-v3@6.5.4` baseline and against the locally packed patched 6.5.4) demonstrates the upstream `MutationObserver.observe(null, ...)` calls fire on rapid mount/unmount cycles and that the patched build produces zero such calls:

```
# baseline md-editor-v3@6.5.4
× CustomScrollbar — race with unmount > rapid mount/unmount never calls MutationObserver.observe(null, ...)
AssertionError: MutationObserver.observe was called with null/undefined:
  [{"target":null,"opts":{"childList":true,"subtree":true}}, ...x6]
  expected [ …(6) ] to deeply equal []

# patched build (npm pack of this branch)
✓ CustomScrollbar.spec.ts (1 test) 174ms
Test Files  1 passed (1)
Tests  1 passed (1)
```

For `useEcharts` / `useMermaid`, the full-package behavioural harness was inconclusive in happy-dom due to environment-level `insertBefore` / network errors masking the null-rootRef throws; the bundled output (`lib/es/chunks/index4.mjs`) shows the upstream pattern `n.value.querySelectorAll(...)` (no guard) versus the patched pattern `const v = n.value; if (!v) return; ... v.querySelectorAll(...)` (guarded) — direct source-map evidence of the fix.

## Related

Related #716 and #748 — these describe related but different unmount races. This PR fixes the `MutationObserver.observe(null)` path and the `rootRef.value.querySelectorAll(...)` paths but does **not** close either of them; the watcher cancellation requested in those issues (cancelling `setTimeout`, microtasks, and mermaid render promises) is a separate change.

## Validation

Local, run against the same checkout:

- `npm ci` — clean (604 packages, 1 pre-existing low-severity audit advisory, unrelated).
- `npm run lint` — 3 pre-existing `import/order` / `no-unused-vars` / `await-thenable` errors remain on `upstream/develop`; **0** new errors introduced by this PR (the 2 errors that fall on the changed files are present on the baseline with the patch stashed). The `--fix` mode also reorders an unrelated `import { ContentPreviewProps } from '../ContentPreview'` line in both `useEcharts.ts` and `useMermaid.ts` — those reorders are deliberately **not** included in this PR (kept minimal to the three intended hunks).
- `npm run build` — clean (vite 7.3.5, all chunks emitted to `lib/es` and `lib/cjs`).
- `git diff --check` — clean.
- `git status` — only the three intended source files are modified (`+15/-3`).
- `git show --stat HEAD` — confirms commit `f3dc7eb3` touches exactly 3 files.
- Source-map check on `lib/es/chunks/index4.mjs` and `lib/es/MdEditor.mjs` — all three guards present in the patched bundle.
- Vitest red/green repro above — patched build passes, baseline fails with 6 null-target `MutationObserver.observe` calls.

No public API, version, changelog, lockfile, or `lib/` is touched in this commit.